### PR TITLE
BBCode color fixes

### DIFF
--- a/bbcode.js
+++ b/bbcode.js
@@ -47,7 +47,7 @@ var XBBCODE = (function() {
     var me = {},
         urlPattern = /^(?:https?|file|c):(?:\/{1,3}|\\{1})[-a-zA-Z0-9:@#%&()~_?\+=\/\\\.]*$/,
         colorNamePattern = /^(?:red|green|blue|orange|yellow|black|white|brown|gray|silver|purple|maroon|fushsia|lime|olive|navy|teal|aqua)$/,
-        colorCodePattern = /^#?[a-fA-F0-9]{6}$/,
+        colorCodePattern = /^#?([a-f0-9]{6}|[a-f0-9]{3})$/i,
         tags,
         tagList,
         tagsNoParseList = [],


### PR DESCRIPTION
BBCode color can be of three or six digits/letters, also adding ignore case flag